### PR TITLE
tokenField lookup in req.params

### DIFF
--- a/src/Strategy.js
+++ b/src/Strategy.js
@@ -74,7 +74,7 @@ class MagicLinkStrategy extends PassportStrategy {
     let user
 
     for (let i = 0; i < this.userFields.length; i++) {
-      const fieldValue = lookup(req.body, this.userFields[i]) || lookup(req.query, this.userFields[i]) || lookup(req.params, this.userFields[i])
+      const fieldValue = lookup(req.body, this.userFields[i]) || lookup(req.query, this.userFields[i])
       if (typeof fieldValue === 'undefined') {
         userFields = null
         break

--- a/src/Strategy.js
+++ b/src/Strategy.js
@@ -74,7 +74,7 @@ class MagicLinkStrategy extends PassportStrategy {
     let user
 
     for (let i = 0; i < this.userFields.length; i++) {
-      const fieldValue = lookup(req.body, this.userFields[i]) || lookup(req.query, this.userFields[i])
+      const fieldValue = lookup(req.body, this.userFields[i]) || lookup(req.query, this.userFields[i]) || lookup(req.params, this.userFields[i])
       if (typeof fieldValue === 'undefined') {
         userFields = null
         break
@@ -136,7 +136,7 @@ class MagicLinkStrategy extends PassportStrategy {
   }
 
   async acceptToken (req, options) {
-    const token = lookup(req.body, this.tokenField) || lookup(req.query, this.tokenField)
+    const token = lookup(req.body, this.tokenField) || lookup(req.query, this.tokenField) || lookup(req.params, this.userFields[i])
 
     if (!token) {
       return this.fail({message: 'Token missing'})

--- a/src/Strategy.js
+++ b/src/Strategy.js
@@ -136,7 +136,7 @@ class MagicLinkStrategy extends PassportStrategy {
   }
 
   async acceptToken (req, options) {
-    const token = lookup(req.body, this.tokenField) || lookup(req.query, this.tokenField) || lookup(req.params, this.userFields[i])
+    const token = lookup(req.body, this.tokenField) || lookup(req.query, this.tokenField) || lookup(req.params, this.tokenField)
 
     if (!token) {
       return this.fail({message: 'Token missing'})


### PR DESCRIPTION
It allows the `tokenField` to be part of the URL path, i.e.:

```javascript
passport.use(
  new MagicLinkStrategy(
    {
      secret: 'some-secret',
      userFields: ['email'],
      tokenField: 'accessToken',
    },
    (req, user, token) => {
      // sendToken
    },
    (user) => {
      // verifyUser
    }
  )
)
```

...

```javascript
app.get(
  '/auth/:accessToken',
  passport.authenticate('magiclink', { action: 'acceptToken' }),
  (req, res) => res.redirect('/')
)
```

@vinialbano, thoughts?