### PR TITLE
feat: support async create and verify token

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ This package supports both CommonJS and ES Modules, and includes TypeScript defi
   The MagicLinkStrategy constructor receives three parameters:
 
   * `options`: A javascript object containing some configuration:
-    * `secret` Mandatory string, used to sign tokens
+    * `secret` String, used to sign tokens. Mandatory unless both `createToken` and `verifyToken` are provided
     * `userFields`: An array of mandatory field names from the request query or body that are going to be used to create or retrieve the user.
     * `tokenField`: The name of the field which contains the token in the request query or body.
     * `ttl`: Optional integer, defaults to 10 minutes (in seconds). It's used to set the token expiration
     * `passReqToCallbacks`: Optional boolean, defaults to false. If true, the request is passed to the `sendToken` and `verifyUser` functions.
     * `verifyUserAfterToken`: Optional boolean, defaults to false. If true, the request data is passed to the token and the user is verified after the token confirmation.
     * `storage`: Optional token storage instance. Defaults to MemoryStorage.
+    * `createToken`: Optional function to generate a JWT token.
+    * `verifyToken`: Optional function to verify a JWT token.
   * `sendToken`: A function that is used to deliver the token to the user. You may use an email service, SMS or whatever method you want. It receives the user object, the token and optionally the request. It returns a promise indicating whether the token has been sent or not.
   * `verifyUser`: A function that receives the request and returns a promise containing the user object. It may be used to insert and/or find the user in the database. It may be executed before the token creation or after the token confirmation.
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ This package supports both CommonJS and ES Modules, and includes TypeScript defi
     * `passReqToCallbacks`: Optional boolean, defaults to false. If true, the request is passed to the `sendToken` and `verifyUser` functions.
     * `verifyUserAfterToken`: Optional boolean, defaults to false. If true, the request data is passed to the token and the user is verified after the token confirmation.
     * `storage`: Optional token storage instance. Defaults to MemoryStorage.
-    * `createToken`: Optional function to generate a JWT token.
-    * `verifyToken`: Optional function to verify a JWT token.
+    * `createToken`: Optional function to generate a JWT token, but if `secret` is not provided it must be provided together with `verifyToken`.
+    * `verifyToken`: Optional function to verify a JWT token, but if `secret` is not provided it must be provided together with `createToken`. It should return the decoded token payload, including an `exp` claim used for token reuse-prevention cleanup.
   * `sendToken`: A function that is used to deliver the token to the user. You may use an email service, SMS or whatever method you want. It receives the user object, the token and optionally the request. It returns a promise indicating whether the token has been sent or not.
   * `verifyUser`: A function that receives the request and returns a promise containing the user object. It may be used to insert and/or find the user in the database. It may be executed before the token creation or after the token confirmation.
 

--- a/src/Strategy.ts
+++ b/src/Strategy.ts
@@ -20,10 +20,24 @@ export interface JWTPayload {
 }
 
 /**
+ * Custom token creation function signature
+ * Receives the payload and TTL, returns a signed token string
+ */
+export type CreateToken = (
+  payload: JWTPayload,
+  ttlSeconds: number
+) => Promise<string>
+
+/**
+ * Custom token verification function signature
+ * Receives a token string, returns the verified payload (or throws on invalid)
+ */
+export type VerifyToken = (token: string) => Promise<JWTPayload>
+
+/**
  * Strategy configuration options
  */
-export interface MagicLinkOptions {
-  secret: string
+export type MagicLinkOptions = {
   userFields: string[]
   tokenField: string
   ttl?: number
@@ -31,8 +45,20 @@ export interface MagicLinkOptions {
   passReqToCallbacks?: boolean
   verifyUserAfterToken?: boolean
   storage?: TokenStorage
-  algorithm?: Algorithm
-}
+} & (
+  | {
+      secret: string
+      algorithm?: Algorithm
+      createToken?: never
+      verifyToken?: never
+    }
+  | {
+      secret?: never
+      algorithm?: never
+      createToken: CreateToken
+      verifyToken: VerifyToken
+    }
+)
 /**
  * Authentication options for authenticate method
  */
@@ -127,13 +153,13 @@ export class MagicLinkStrategy extends Strategy {
   public readonly name: string = 'magiclink'
 
   // Configuration properties
-  private readonly secret: string
   private readonly ttlSeconds: number
-  private readonly algorithm: Algorithm
   private readonly allowPost: boolean
   private readonly userFields: readonly string[]
   private readonly tokenField: string
   private readonly storage: TokenStorage
+  private readonly createTokenFn: CreateToken
+  private readonly verifyTokenFn: VerifyToken
 
   // Callback properties
   private readonly sendToken: SendToken
@@ -170,9 +196,14 @@ export class MagicLinkStrategy extends Strategy {
     super()
 
     // Validate required options
-    if (!options.secret) {
+    const hasCustomTokenFns =
+      'createToken' in options &&
+      'verifyToken' in options &&
+      options.createToken &&
+      options.verifyToken
+    if (!options.secret && !hasCustomTokenFns) {
       throw new Error(
-        'Magic Link authentication strategy requires an encryption secret'
+        'Magic Link authentication strategy requires either a secret or both createToken and verifyToken functions'
       )
     }
     if (!options.userFields || !options.userFields.length) {
@@ -197,11 +228,27 @@ export class MagicLinkStrategy extends Strategy {
     }
 
     // Initialize configuration properties
-    this.secret = validateSecret(options.secret)
+    if (options.createToken && options.verifyToken) {
+      this.createTokenFn = options.createToken
+      this.verifyTokenFn = options.verifyToken
+    } else {
+      const secret = validateSecret(options.secret)
+      const algorithm = options.algorithm ?? 'HS256'
+      this.createTokenFn = async (payload: JWTPayload, ttlSeconds: number) => {
+        const jwtOptions = {
+          expiresIn: ttlSeconds,
+          algorithm
+        }
+        return jwt.sign(payload, secret, jwtOptions)
+      }
+      this.verifyTokenFn = async (token: string) => {
+        const jwtOptions = { algorithms: [algorithm] }
+        return jwt.verify(token, secret, jwtOptions) as JWTPayload
+      }
+    }
     this.userFields = validateUserFields(options.userFields)
     this.tokenField = options.tokenField
     this.ttlSeconds = validateTTL(options.ttl ?? DEFAULT_TTL_SECONDS)
-    this.algorithm = options.algorithm ?? 'HS256'
     this.allowPost = options.allowPost ?? true
     this.storage = options.storage ?? new MemoryStorage()
 
@@ -245,7 +292,7 @@ export class MagicLinkStrategy extends Strategy {
     const user = await this.verifyUserBeforeToken(userFields, req, options)
     if (!user) return
 
-    const token = this.generateToken(user)
+    const token = await this.generateToken(user)
     if (!token) return
 
     const delivered = await this.deliverToken(token, user, req)
@@ -324,15 +371,10 @@ export class MagicLinkStrategy extends Strategy {
   /**
    * Generate JWT token
    */
-  private generateToken(user: User): string | null {
+  private async generateToken(user: User): Promise<string | null> {
     try {
-      const payload = { user, iat: Math.floor(Date.now() / 1000) }
-      const jwtOptions = {
-        expiresIn: this.ttlSeconds,
-        algorithm: this.algorithm
-      }
-
-      return jwt.sign(payload, this.secret, jwtOptions)
+      const payload: JWTPayload = { user, iat: Math.floor(Date.now() / 1000) }
+      return await this.createTokenFn(payload, this.ttlSeconds)
     } catch (error) {
       console.error('Token generation failed:', error)
       this.error(new Error('Authentication failed'))
@@ -372,7 +414,7 @@ export class MagicLinkStrategy extends Strategy {
     const tokenString = this.extractToken(req)
     if (!tokenString) return
 
-    const verificationResult = this.verifyJwtToken(tokenString)
+    const verificationResult = await this.verifyJwtToken(tokenString)
     if (!verificationResult) return
 
     const { user: initialUser, tokenExpiration } = verificationResult
@@ -419,16 +461,11 @@ export class MagicLinkStrategy extends Strategy {
   /**
    * Verify JWT token and extract payload
    */
-  private verifyJwtToken(
+  private async verifyJwtToken(
     tokenString: string
-  ): { user: User; tokenExpiration: number } | null {
+  ): Promise<{ user: User; tokenExpiration: number } | null> {
     try {
-      const jwtOptions = { algorithms: [this.algorithm] }
-      const payload = jwt.verify(
-        tokenString,
-        this.secret,
-        jwtOptions
-      ) as JWTPayload
+      const payload = await this.verifyTokenFn(tokenString)
 
       return {
         user: payload.user,

--- a/src/Strategy.ts
+++ b/src/Strategy.ts
@@ -206,6 +206,11 @@ export class MagicLinkStrategy extends Strategy {
         'Magic Link authentication strategy requires either a secret or both createToken and verifyToken functions'
       )
     }
+    if (options.secret && hasCustomTokenFns) {
+      throw new Error(
+        'Cannot provide both secret and custom token functions. Please choose one method for token handling.'
+      )
+    }
     if (!options.userFields || !options.userFields.length) {
       throw new Error(
         'Magic Link authentication strategy requires an array of mandatory user fields'

--- a/src/__tests__/Strategy.spec.ts
+++ b/src/__tests__/Strategy.spec.ts
@@ -48,6 +48,24 @@ describe('MagicLinkStrategy - Validation', () => {
       ).toThrow('Secret cannot be empty')
     })
 
+    it('should throw error if secret and custom token functions are both provided', () => {
+      expect(
+        () =>
+          new MagicLinkStrategy(
+            {
+              ...validOptions,
+              secret: 'test-secret',
+              createToken: async () => 'token',
+              verifyToken: async () => ({ user: {}, iat: 0 })
+            } as never,
+            sendToken,
+            verifyUser
+          )
+      ).toThrow(
+        'Cannot provide both secret and custom token functions. Please choose one method for token handling.'
+      )
+    })
+
     it('should throw error if userFields is empty array', () => {
       expect(
         () =>
@@ -228,8 +246,7 @@ describe('MagicLinkStrategy - Validation', () => {
 
     it('should accept createToken and verifyToken without secret', () => {
       expect(
-        () =>
-          new MagicLinkStrategy(customTokenOptions, sendToken, verifyUser)
+        () => new MagicLinkStrategy(customTokenOptions, sendToken, verifyUser)
       ).not.toThrow()
     })
 

--- a/src/__tests__/Strategy.spec.ts
+++ b/src/__tests__/Strategy.spec.ts
@@ -1,5 +1,6 @@
+import jwt from 'jsonwebtoken'
 import { MemoryStorage } from '../MemoryStorage.js'
-import { MagicLinkStrategy } from '../Strategy.js'
+import { MagicLinkStrategy, type JWTPayload } from '../Strategy.js'
 
 describe('MagicLinkStrategy - Validation', () => {
   const validOptions = {
@@ -19,7 +20,7 @@ describe('MagicLinkStrategy - Validation', () => {
       expect(
         () => new MagicLinkStrategy(optionsWithoutSecret, sendToken, verifyUser)
       ).toThrow(
-        'Magic Link authentication strategy requires an encryption secret'
+        'Magic Link authentication strategy requires either a secret or both createToken and verifyToken functions'
       )
     })
 
@@ -32,7 +33,7 @@ describe('MagicLinkStrategy - Validation', () => {
             verifyUser
           )
       ).toThrow(
-        'Magic Link authentication strategy requires an encryption secret'
+        'Magic Link authentication strategy requires either a secret or both createToken and verifyToken functions'
       )
     })
 
@@ -209,6 +210,61 @@ describe('MagicLinkStrategy - Validation', () => {
             verifyUser
           )
       ).not.toThrow()
+    })
+  })
+
+  describe('Custom Token Functions', () => {
+    const customTokenOptions = {
+      userFields: ['email'],
+      tokenField: 'token',
+      ttl: 600,
+      createToken: async (payload: JWTPayload, ttlSeconds: number) => {
+        return jwt.sign(payload, 'async-secret', { expiresIn: ttlSeconds })
+      },
+      verifyToken: async (token: string) => {
+        return jwt.verify(token, 'async-secret') as JWTPayload
+      }
+    }
+
+    it('should accept createToken and verifyToken without secret', () => {
+      expect(
+        () =>
+          new MagicLinkStrategy(customTokenOptions, sendToken, verifyUser)
+      ).not.toThrow()
+    })
+
+    it('should throw if only createToken is provided without verifyToken', () => {
+      expect(
+        () =>
+          new MagicLinkStrategy(
+            {
+              userFields: ['email'],
+              tokenField: 'token',
+              createToken: customTokenOptions.createToken
+            } as never,
+            sendToken,
+            verifyUser
+          )
+      ).toThrow(
+        'Magic Link authentication strategy requires either a secret or both createToken and verifyToken functions'
+      )
+    })
+
+    it('should throw if only verifyToken is provided without createToken', () => {
+      expect(
+        () =>
+          new MagicLinkStrategy(
+            {
+              userFields: ['email'],
+              tokenField: 'token',
+              verifyToken: customTokenOptions.verifyToken
+            } as never,
+            sendToken,
+            verifyUser
+          )
+      ).toThrow(
+        'Magic Link authentication strategy requires either a secret or both createToken and verifyToken functions'
+      )
     })
   })
 

--- a/src/__tests__/integration/Strategy.test.ts
+++ b/src/__tests__/integration/Strategy.test.ts
@@ -1,6 +1,7 @@
 import { Request } from 'express'
+import jwt from 'jsonwebtoken'
 import { MemoryStorage } from '../../MemoryStorage.js'
-import { MagicLinkOptions } from '../../Strategy.js'
+import { type JWTPayload, MagicLinkOptions } from '../../Strategy.js'
 import { testUsers } from '../support/fixtures.js'
 import {
   clearCapturedToken,
@@ -501,6 +502,125 @@ describe('MagicLinkStrategy - Integration Tests', () => {
         expect(customStorage.get).toHaveBeenCalled()
         expect(customStorage.set).toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('custom createToken/verifyToken', () => {
+    const asyncSecret = 'async-signing-secret'
+
+    const makeCustomTokenStrategy = (
+      overrides: Partial<MagicLinkOptions> = {}
+    ) => {
+      const options = {
+        userFields: ['email', 'name'] as string[],
+        tokenField: 'token',
+        createToken: async (payload: JWTPayload, ttlSeconds: number) => {
+          return jwt.sign(payload, asyncSecret, { expiresIn: ttlSeconds })
+        },
+        verifyToken: async (token: string) => {
+          return jwt.verify(token, asyncSecret) as JWTPayload
+        },
+        ...overrides
+      }
+      return createTestStrategy(options as Partial<MagicLinkOptions>, sendToken, verifyUser)
+    }
+
+    it('should complete full authentication cycle with custom token functions', async () => {
+      const storage = new MemoryStorage()
+      const strategy = makeCustomTokenStrategy({
+        storage,
+        verifyUserAfterToken: true
+      })
+
+      // Step 1: Request magic link
+      await testStrategyPass(strategy, setupRequest(testUsers.valid), {
+        action: 'requestToken'
+      })
+
+      const token = getCapturedToken()!
+      expect(token).toBeTruthy()
+
+      // Step 2: Accept token
+      const { user } = await testStrategySuccess(
+        strategy,
+        setupRequest({ token }),
+        { action: 'acceptToken' }
+      )
+
+      expect(user).toEqual(testUsers.valid)
+    })
+
+    it('should prevent token reuse with custom token functions', async () => {
+      const storage = new MemoryStorage()
+      const strategy = makeCustomTokenStrategy({
+        storage,
+        verifyUserAfterToken: true
+      })
+
+      // Generate and use token
+      await testStrategyPass(strategy, setupRequest(testUsers.valid), {
+        action: 'requestToken'
+      })
+
+      const token = getCapturedToken()!
+
+      await testStrategySuccess(
+        strategy,
+        setupRequest({ token }),
+        { action: 'acceptToken' }
+      )
+
+      // Second use should fail
+      const { challenge } = await testStrategyFailure(
+        strategy,
+        setupRequest({ token }),
+        { action: 'acceptToken' }
+      )
+
+      expect(challenge).toBe('Token was already used')
+    })
+
+    it('should fail with Invalid token when verifyToken rejects', async () => {
+      const strategy = makeCustomTokenStrategy({
+        verifyUserAfterToken: false
+      })
+
+      // Use a token signed with a different secret
+      const badToken = jwt.sign({ user: testUsers.valid }, 'wrong-secret', {
+        expiresIn: 600
+      })
+
+      const { challenge } = await testStrategyFailure(
+        strategy,
+        setupRequest({ token: badToken }),
+        { action: 'acceptToken' }
+      )
+
+      expect(challenge).toBe('Invalid token')
+    })
+
+    it('should handle createToken failure gracefully', async () => {
+      const strategy = createTestStrategy(
+        {
+          createToken: async () => {
+            throw new Error('KMS unavailable')
+          },
+          verifyToken: async (token: string) => {
+            return jwt.verify(token, asyncSecret) as JWTPayload
+          },
+          verifyUserAfterToken: false
+        } as Partial<MagicLinkOptions>,
+        sendToken,
+        verifyUser
+      )
+
+      const error = await testStrategyError(
+        strategy,
+        setupRequest(testUsers.valid),
+        { action: 'requestToken' }
+      )
+
+      expect(error.message).toBe('Authentication failed')
     })
   })
 })

--- a/src/__tests__/support/fixtures.ts
+++ b/src/__tests__/support/fixtures.ts
@@ -36,7 +36,6 @@ export const testUsers = {
 
 export const testOptions = {
   minimal: {
-    secret: 'top-secret',
     userFields: ['email', 'name'] as string[],
     tokenField: 'token'
   },

--- a/src/__tests__/support/testHelpers.ts
+++ b/src/__tests__/support/testHelpers.ts
@@ -143,7 +143,9 @@ export const createTestStrategy = (
   sendToken = createMockSendToken(),
   verifyUser = createMockVerifyUser(testUsers.valid)
 ): MagicLinkStrategy => {
-  options.secret ??= 'top-secret'
+  if (!options.secret && !(options.createToken && options.verifyToken)) {
+    options.secret = 'top-secret'
+  }
   return new MagicLinkStrategy(
     { ...testOptions.minimal, ...options } as MagicLinkOptions,
     sendToken,

--- a/src/__tests__/support/testHelpers.ts
+++ b/src/__tests__/support/testHelpers.ts
@@ -145,7 +145,7 @@ export const createTestStrategy = (
 ): MagicLinkStrategy => {
   options.secret ??= 'top-secret'
   return new MagicLinkStrategy(
-    { ...testOptions.minimal, ...options },
+    { ...testOptions.minimal, ...options } as MagicLinkOptions,
     sendToken,
     verifyUser
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,8 @@ export { lookup } from './lookup.js'
 export { MemoryStorage } from './MemoryStorage.js'
 export type { TokenStorage } from './MemoryStorage.js'
 export { MagicLinkStrategy as Strategy } from './Strategy.js'
-export type { MagicLinkOptions as MagicLinkStrategyOptions } from './Strategy.js'
+export type {
+  MagicLinkOptions as MagicLinkStrategyOptions,
+  CreateToken,
+  VerifyToken
+} from './Strategy.js'


### PR DESCRIPTION
We've been using your library for a couple of years and have generally been very happy. We're trying to eliminate static secrets throughout our codebase and would like to have the ability to rotate secrets without customer impact though. Ideally, we would like to re-use our existing RSA key infrastructure. 

This PR adds an optional `createToken` and `verifyToken` callbacks to MagicLinkOptions as an alternative to the `secret` option. This enables asymmetric key signing (e.g., RS256), key rotation, KMS integration, and external token services.

Both `generateToken()` and `verifyJwtToken()` are now async to support custom signing functions. The `secret`-based API remains fully backward compatible.