### PR TITLE
feat: add tokenExpiredMessage and tokenInvalidMessage options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ passport.use(new Strategy(options, sendToken, verifyUser))
   * `allowReuse`: A boolean indicating whether a token can be used more than once. Defaults to `false`.
   * `userPrimaryKey`: A string containing the primary key of the user object. This is only used if the token cannot be reused. Defaults to `email`.
   * `tokenAlreadyUsedMessage`: A string containing the error message if the token has already been used. Defaults to `Token was already used`.
+  * `tokenExpiredMessage`: A string containing the error message if the token has expired. Defaults to `Invalid token`.
+  * `tokenInvalidMessage`: A string containing the error message if the token is invalid. Defaults to `Invalid token`.
   
   ```javascript
   app.get('/auth/magiclink/callback',

--- a/src/Strategy.ts
+++ b/src/Strategy.ts
@@ -68,6 +68,8 @@ export interface MagicLinkAuthenticateOptions {
   allowReuse?: boolean
   userPrimaryKey?: string
   tokenAlreadyUsedMessage?: string
+  tokenExpiredMessage?: string
+  tokenInvalidMessage?: string
 }
 
 declare module 'passport' {
@@ -96,6 +98,14 @@ type VerifyUserCallbackWithReq = (
   userFields: Record<string, unknown>
 ) => Promise<User | null>
 export type VerifyUser = VerifyUserCallback | VerifyUserCallbackWithReq
+
+/**
+ * Token verification error shape, as thrown by verifyTokenFn
+ */
+type TokenVerificationError = {
+  name?: unknown
+  expiredAt?: unknown
+}
 
 // Configuration validation constants
 const DEFAULT_TTL_SECONDS = 600 // 10 minutes
@@ -141,6 +151,20 @@ function validateSecret(value: string): string {
     throw new Error('Secret cannot be empty')
   }
   return value
+}
+
+/**
+ * Returns true if a verification error was caused by an expired token,
+ * covering jsonwebtoken (TokenExpiredError, expiredAt) and jose (JWTExpired)
+ */
+function isExpiredTokenError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+
+  const { name, expiredAt } = error as TokenVerificationError
+
+  return (
+    name === 'TokenExpiredError' || name === 'JWTExpired' || expiredAt != null
+  )
 }
 
 /**
@@ -419,7 +443,7 @@ export class MagicLinkStrategy extends Strategy {
     const tokenString = this.extractToken(req)
     if (!tokenString) return
 
-    const verificationResult = await this.verifyJwtToken(tokenString)
+    const verificationResult = await this.verifyJwtToken(tokenString, options)
     if (!verificationResult) return
 
     const { user: initialUser, tokenExpiration } = verificationResult
@@ -467,7 +491,8 @@ export class MagicLinkStrategy extends Strategy {
    * Verify JWT token and extract payload
    */
   private async verifyJwtToken(
-    tokenString: string
+    tokenString: string,
+    options: MagicLinkAuthenticateOptions
   ): Promise<{ user: User; tokenExpiration: number } | null> {
     try {
       const payload = await this.verifyTokenFn(tokenString)
@@ -478,7 +503,13 @@ export class MagicLinkStrategy extends Strategy {
       }
     } catch (error) {
       console.error('Token verification failed:', error)
-      this.fail('Invalid token', 401)
+
+      const message = isExpiredTokenError(error)
+        ? options.tokenExpiredMessage
+        : options.tokenInvalidMessage
+
+      this.fail(message ?? 'Invalid token', 401)
+
       return null
     }
   }

--- a/src/__tests__/integration/Strategy.test.ts
+++ b/src/__tests__/integration/Strategy.test.ts
@@ -12,6 +12,7 @@ import {
   MockVerifyUser
 } from '../support/mockFactories.js'
 import {
+  createExpiredToken,
   createTestStrategy,
   createValidToken,
   testStrategyError,
@@ -160,6 +161,15 @@ describe('MagicLinkStrategy - Integration Tests', () => {
     })
 
     describe('custom messages', () => {
+      let spy: jest.Spied<typeof console.error>
+      beforeEach(() => {
+        spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      })
+
+      afterEach(() => {
+        spy.mockRestore()
+      })
+
       it('should use custom tokenAlreadyUsedMessage', async () => {
         const storage = new MemoryStorage()
         const strategy = makeStrategy({ storage, verifyUserAfterToken: true })
@@ -199,6 +209,40 @@ describe('MagicLinkStrategy - Integration Tests', () => {
           strategy,
           setupRequest({ token: validToken }),
           { action: 'acceptToken', authMessage: customMessage }
+        )
+
+        expect(challenge).toBe(customMessage)
+      })
+
+      it('should use custom tokenExpiredMessage', async () => {
+        const storage = new MemoryStorage()
+        const strategy = makeStrategy({ storage })
+        const customMessage =
+          'This magic link has expired. Please request a new one.'
+
+        const expiredToken = createExpiredToken(testUsers.valid, 'top-secret')
+
+        const { challenge } = await testStrategyFailure(
+          strategy,
+          setupRequest({ token: expiredToken }),
+          { action: 'acceptToken', tokenExpiredMessage: customMessage }
+        )
+
+        expect(challenge).toBe(customMessage)
+      })
+
+      it('should use custom tokenInvalidMessage', async () => {
+        const storage = new MemoryStorage()
+        const strategy = makeStrategy({ storage })
+        const customMessage =
+          'This magic link is invalid. Please request a new one.'
+
+        const invalidToken = 'invalidToken'
+
+        const { challenge } = await testStrategyFailure(
+          strategy,
+          setupRequest({ token: invalidToken }),
+          { action: 'acceptToken', tokenInvalidMessage: customMessage }
         )
 
         expect(challenge).toBe(customMessage)
@@ -522,7 +566,11 @@ describe('MagicLinkStrategy - Integration Tests', () => {
         },
         ...overrides
       }
-      return createTestStrategy(options as Partial<MagicLinkOptions>, sendToken, verifyUser)
+      return createTestStrategy(
+        options as Partial<MagicLinkOptions>,
+        sendToken,
+        verifyUser
+      )
     }
 
     it('should complete full authentication cycle with custom token functions', async () => {
@@ -564,11 +612,9 @@ describe('MagicLinkStrategy - Integration Tests', () => {
 
       const token = getCapturedToken()!
 
-      await testStrategySuccess(
-        strategy,
-        setupRequest({ token }),
-        { action: 'acceptToken' }
-      )
+      await testStrategySuccess(strategy, setupRequest({ token }), {
+        action: 'acceptToken'
+      })
 
       // Second use should fail
       const { challenge } = await testStrategyFailure(


### PR DESCRIPTION
We'd like to tell the end user to request a new link when the link has expired however that information is only logged. `verifyJwtToken` catches every verification error and fails with a single `"Invalid token"` challenge so all failures look identical to the callback.

This adds two optional messages, matching the `tokenAlreadyUsedMessage` pattern that's already there:

```ts
tokenExpiredMessage: 'magic_link_expired',
tokenInvalidMessage: 'magic_link_invalid'
```

Both fall back to `"Invalid token"` so there is no behaviour change unless the consumer opts in.

`isExpiredTokenError` handles the expired JWT errors raised by `jsonwebtoken` and `jose` libraries.